### PR TITLE
Add character domain models and CLI tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,99 @@
 # TTRPGtools
+
+Utilities for managing tabletop role-playing game characters from the command line.
+
+## Installation
+
+The project is a pure Python package that can be executed directly from the repository:
+
+```bash
+python -m ttrpgtools.cli --help
+```
+
+## Careers and advances
+
+Two sample careers are bundled so you can get started immediately:
+
+- **Soldier** with the advances Basic Training, Shield Wall, and Battlefield Commander.
+- **Acolyte** with the advances Initiate's Blessing, Sacred Ward, and Miracle Worker.
+
+Each advance has an XP cost, a rulebook page reference, and optional prerequisites. A
+character cannot purchase an advance unless they have enough unspent XP and own all of
+its prerequisites.
+
+## CLI usage
+
+Create a new character and save it to disk:
+
+```bash
+python -m ttrpgtools.cli new \
+  --name "Sera" \
+  --career "Soldier" \
+  --xp 500 \
+  --output sera.json
+```
+
+List the built-in careers and their advances:
+
+```bash
+python -m ttrpgtools.cli list
+```
+
+Buy an advance, automatically recording the rulebook page number:
+
+```bash
+python -m ttrpgtools.cli buy-advance --file sera.json --advance "Shield Wall"
+```
+
+Override the recorded page number if your table uses a different printing:
+
+```bash
+python -m ttrpgtools.cli buy-advance \
+  --file sera.json \
+  --advance "Shield Wall" \
+  --page 148
+```
+
+View a character summary:
+
+```bash
+python -m ttrpgtools.cli show --file sera.json
+```
+
+Export the character as JSON (the `load` command mirrors `show` but supports raw JSON):
+
+```bash
+python -m ttrpgtools.cli load --file sera.json --json
+```
+
+Import or update a character from a JSON document:
+
+```bash
+python -m ttrpgtools.cli save --source ./sera-updated.json --file sera.json
+```
+
+You can also pipe JSON directly from other tools:
+
+```bash
+jq '{"name":"Sera","career":"Soldier","xp_total":500,"purchases":[]}' \
+  | python -m ttrpgtools.cli save --stdin --file sera.json
+```
+
+## JSON schema notes
+
+Characters are stored as human-editable JSON files with the following structure:
+
+```json
+{
+  "name": "Sera",
+  "career": "Soldier",
+  "xp_total": 500,
+  "purchases": [
+    {"name": "Basic Training", "xp_cost": 100, "page": 45}
+  ]
+}
+```
+
+The `purchases` array records each advance by name, the XP spent, and the rulebook page
+number. XP spent is automatically calculated from the canonical advance definition for
+that career, so you only need to adjust the page number when editing manually.

--- a/ttrpgtools/__init__.py
+++ b/ttrpgtools/__init__.py
@@ -1,0 +1,22 @@
+"""Core package for TTRPG tools."""
+
+from .models import Advance, AdvancePurchase, Career, Character, CAREERS, get_career
+from .storage import (
+    character_from_dict,
+    character_to_dict,
+    load_character,
+    save_character,
+)
+
+__all__ = [
+    "Advance",
+    "AdvancePurchase",
+    "Career",
+    "Character",
+    "CAREERS",
+    "get_career",
+    "character_from_dict",
+    "character_to_dict",
+    "load_character",
+    "save_character",
+]

--- a/ttrpgtools/cli.py
+++ b/ttrpgtools/cli.py
@@ -1,0 +1,142 @@
+"""Command line interface for the TTRPG tools."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Iterable
+
+from .models import CAREERS, PrerequisiteError, Character, get_career
+from .storage import character_from_dict, character_to_dict, load_character, save_character
+
+
+def _career_list() -> str:
+    lines = []
+    for career in CAREERS.values():
+        lines.append(f"{career.name}")
+        for advance in career.advances.values():
+            prereqs = ", ".join(advance.prerequisites) or "None"
+            lines.append(
+                f"  - {advance.name} (XP {advance.xp_cost}, page {advance.page}, prerequisites: {prereqs})"
+            )
+    return "\n".join(lines)
+
+
+def _load_character_or_exit(path: str | Path):
+    try:
+        return load_character(path)
+    except FileNotFoundError:
+        raise SystemExit(f"Character file '{path}' does not exist.")
+    except Exception as exc:  # pragma: no cover - defensive path
+        raise SystemExit(f"Could not load character: {exc}") from exc
+
+
+def _save_character_or_exit(character, path: str | Path) -> None:
+    try:
+        save_character(character, path)
+    except Exception as exc:  # pragma: no cover - defensive path
+        raise SystemExit(f"Could not save character: {exc}") from exc
+
+
+def cmd_new(args: argparse.Namespace) -> None:
+    career = get_career(args.career)
+    character = Character(name=args.name, career=career, xp_total=args.xp)
+    if args.output:
+        _save_character_or_exit(character, args.output)
+    print(character.to_summary())
+
+
+def cmd_buy_advance(args: argparse.Namespace) -> None:
+    character = _load_character_or_exit(args.file)
+    try:
+        purchase = character.purchase_advance(args.advance, page_override=args.page)
+    except PrerequisiteError as exc:
+        raise SystemExit(str(exc))
+    _save_character_or_exit(character, args.file)
+    print(
+        f"Purchased {purchase.name} for {purchase.xp_cost} XP (page {purchase.page}). XP remaining: {character.xp_available}."
+    )
+
+
+def cmd_list(args: argparse.Namespace) -> None:  # noqa: ARG001 - argparse API
+    print(_career_list())
+
+
+def cmd_show(args: argparse.Namespace) -> None:
+    character = _load_character_or_exit(args.file)
+    print(character.to_summary())
+
+
+def cmd_save(args: argparse.Namespace) -> None:
+    character_data = json.load(sys.stdin) if args.stdin else json.loads(Path(args.source).read_text())
+    character = character_from_dict(character_data)
+    _save_character_or_exit(character, args.file)
+    print(f"Character saved to {args.file}.")
+
+
+def cmd_load(args: argparse.Namespace) -> None:
+    character = _load_character_or_exit(args.file)
+    if args.json:
+        print(json.dumps(character_to_dict(character), indent=2))
+    else:
+        print(character.to_summary())
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Tools for managing TTRPG characters.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    new_parser = subparsers.add_parser("new", help="Create a new character")
+    new_parser.add_argument("--name", required=True, help="Character name")
+    new_parser.add_argument("--career", required=True, help="Career name")
+    new_parser.add_argument("--xp", type=int, default=0, help="Total XP available")
+    new_parser.add_argument("--output", help="File path to save the new character")
+    new_parser.set_defaults(func=cmd_new)
+
+    buy_parser = subparsers.add_parser("buy-advance", help="Purchase an advance")
+    buy_parser.add_argument("--file", required=True, help="Character file path")
+    buy_parser.add_argument("--advance", required=True, help="Advance name to purchase")
+    buy_parser.add_argument("--page", type=int, help="Override rulebook page number")
+    buy_parser.set_defaults(func=cmd_buy_advance)
+
+    list_parser = subparsers.add_parser("list", help="List careers and advances")
+    list_parser.set_defaults(func=cmd_list)
+
+    show_parser = subparsers.add_parser("show", help="Display a character summary")
+    show_parser.add_argument("--file", required=True, help="Character file path")
+    show_parser.set_defaults(func=cmd_show)
+
+    save_parser = subparsers.add_parser("save", help="Save character data to a file")
+    save_parser.add_argument("--file", required=True, help="Destination file path")
+    group = save_parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--source", help="Path to a JSON document describing the character")
+    group.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read JSON from stdin",
+    )
+    save_parser.set_defaults(func=cmd_save)
+
+    load_parser = subparsers.add_parser("load", help="Load a character file")
+    load_parser.add_argument("--file", required=True, help="Character file path")
+    load_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the character as raw JSON instead of a summary",
+    )
+    load_parser.set_defaults(func=cmd_load)
+
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/ttrpgtools/models.py
+++ b/ttrpgtools/models.py
@@ -1,0 +1,168 @@
+"""Domain models for TTRPG character management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Sequence
+
+
+class PrerequisiteError(ValueError):
+    """Raised when an advance cannot be purchased."""
+
+
+@dataclass(frozen=True)
+class Advance:
+    """Represents an advance available to a career."""
+
+    name: str
+    xp_cost: int
+    page: int
+    prerequisites: Sequence[str] = field(default_factory=tuple)
+
+    def missing_prerequisites(self, owned_advances: Iterable[str]) -> List[str]:
+        """Return prerequisites that are not in ``owned_advances``."""
+        owned_set = {name.lower() for name in owned_advances}
+        return [name for name in self.prerequisites if name.lower() not in owned_set]
+
+
+@dataclass(frozen=True)
+class AdvancePurchase:
+    """Represents a purchased advance recorded on a character sheet."""
+
+    name: str
+    xp_cost: int
+    page: int
+
+
+@dataclass
+class Career:
+    """A career that defines a list of advances."""
+
+    name: str
+    advances: Dict[str, Advance]
+
+    def get_advance(self, advance_name: str) -> Advance:
+        try:
+            return self.advances[advance_name.lower()]
+        except KeyError as exc:
+            raise KeyError(f"Advance '{advance_name}' not found for career '{self.name}'.") from exc
+
+    @classmethod
+    def from_advances(cls, name: str, advances: Sequence[Advance]) -> "Career":
+        return cls(name=name, advances={adv.name.lower(): adv for adv in advances})
+
+
+@dataclass
+class Character:
+    """A character with XP accounting and advance purchases."""
+
+    name: str
+    career: Career
+    xp_total: int = 0
+    purchases: List[AdvancePurchase] = field(default_factory=list)
+
+    def has_advance(self, advance_name: str) -> bool:
+        return any(purchase.name.lower() == advance_name.lower() for purchase in self.purchases)
+
+    @property
+    def xp_spent(self) -> int:
+        return sum(purchase.xp_cost for purchase in self.purchases)
+
+    @property
+    def xp_available(self) -> int:
+        return self.xp_total - self.xp_spent
+
+    def _validate_purchase(self, advance: Advance) -> None:
+        if self.has_advance(advance.name):
+            raise PrerequisiteError(f"Advance '{advance.name}' has already been purchased.")
+
+        missing = advance.missing_prerequisites(purchase.name for purchase in self.purchases)
+        if missing:
+            raise PrerequisiteError(
+                "Missing prerequisites: " + ", ".join(missing)
+            )
+
+        if advance.xp_cost > self.xp_available:
+            raise PrerequisiteError(
+                f"Not enough XP. Cost: {advance.xp_cost}, available: {self.xp_available}."
+            )
+
+    def purchase_advance(self, advance_name: str, *, page_override: int | None = None) -> AdvancePurchase:
+        advance = self.career.get_advance(advance_name)
+        self._validate_purchase(advance)
+
+        recorded_page = page_override if page_override is not None else advance.page
+        purchase = AdvancePurchase(name=advance.name, xp_cost=advance.xp_cost, page=recorded_page)
+        self.purchases.append(purchase)
+        return purchase
+
+    def to_summary(self) -> str:
+        lines = [
+            f"Name: {self.name}",
+            f"Career: {self.career.name}",
+            f"XP Total: {self.xp_total}",
+            f"XP Spent: {self.xp_spent}",
+            f"XP Available: {self.xp_available}",
+            "Advances:",
+        ]
+        if not self.purchases:
+            lines.append("  (none)")
+        else:
+            for purchase in self.purchases:
+                lines.append(
+                    f"  - {purchase.name} (XP {purchase.xp_cost}, page {purchase.page})"
+                )
+        return "\n".join(lines)
+
+
+CAREERS: Dict[str, Career] = {}
+
+
+def register_career(career: Career) -> None:
+    CAREERS[career.name.lower()] = career
+
+
+def get_career(name: str) -> Career:
+    try:
+        return CAREERS[name.lower()]
+    except KeyError as exc:
+        raise KeyError(f"Career '{name}' is not registered.") from exc
+
+
+# Built-in sample careers
+register_career(
+    Career.from_advances(
+        "Soldier",
+        [
+            Advance("Basic Training", xp_cost=100, page=45),
+            Advance("Shield Wall", xp_cost=150, page=47, prerequisites=["Basic Training"]),
+            Advance(
+                "Battlefield Commander",
+                xp_cost=300,
+                page=52,
+                prerequisites=["Shield Wall"],
+            ),
+        ],
+    )
+)
+
+register_career(
+    Career.from_advances(
+        "Acolyte",
+        [
+            Advance("Initiate's Blessing", xp_cost=100, page=78),
+            Advance(
+                "Sacred Ward",
+                xp_cost=200,
+                page=82,
+                prerequisites=["Initiate's Blessing"],
+            ),
+            Advance(
+                "Miracle Worker",
+                xp_cost=400,
+                page=90,
+                prerequisites=["Sacred Ward"],
+            ),
+        ],
+    )
+)

--- a/ttrpgtools/storage.py
+++ b/ttrpgtools/storage.py
@@ -1,0 +1,58 @@
+"""Helpers for serialising and deserialising characters to JSON."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from .models import AdvancePurchase, Career, Character, get_career
+
+
+def character_to_dict(character: Character) -> Dict[str, Any]:
+    return {
+        "name": character.name,
+        "career": character.career.name,
+        "xp_total": character.xp_total,
+        "purchases": [
+            {"name": purchase.name, "xp_cost": purchase.xp_cost, "page": purchase.page}
+            for purchase in character.purchases
+        ],
+    }
+
+
+def character_from_dict(payload: Dict[str, Any]) -> Character:
+    career_name = payload["career"]
+    career: Career = get_career(career_name)
+    character = Character(
+        name=payload["name"],
+        career=career,
+        xp_total=int(payload.get("xp_total", 0)),
+    )
+    for purchase_data in payload.get("purchases", []):
+        advance_name = purchase_data["name"]
+        page = int(purchase_data.get("page"))
+        # Validate against career definition and prerequisites.
+        advance = career.get_advance(advance_name)
+        missing = advance.missing_prerequisites(p.name for p in character.purchases)
+        if missing:
+            raise ValueError(
+                f"Advance '{advance.name}' is missing prerequisites: {', '.join(missing)}"
+            )
+        character.purchases.append(
+            AdvancePurchase(name=advance.name, xp_cost=advance.xp_cost, page=page)
+        )
+    if character.xp_spent > character.xp_total:
+        raise ValueError(
+            f"Character spends {character.xp_spent} XP but only has {character.xp_total}."
+        )
+    return character
+
+
+def save_character(character: Character, path: str | Path) -> None:
+    Path(path).write_text(json.dumps(character_to_dict(character), indent=2))
+
+
+def load_character(path: str | Path) -> Character:
+    data = json.loads(Path(path).read_text())
+    return character_from_dict(data)


### PR DESCRIPTION
## Summary
- add domain models and sample career data with XP and prerequisite validation
- implement an argparse-powered CLI with JSON storage helpers for character management
- document CLI usage examples and JSON schema guidance in the README

## Testing
- python -m ttrpgtools.cli list
- python -m ttrpgtools.cli new --name Sera --career Soldier --xp 500 --output sera.json
- python -m ttrpgtools.cli buy-advance --file sera.json --advance "Basic Training"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69131583b228832786e3fe314a8bbd38)