### PR TITLE
Add sample character generator and modifier scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,23 @@ Characters are stored as human-editable JSON files with the following structure:
 The `purchases` array records each advance by name, the XP spent, and the rulebook page
 number. XP spent is automatically calculated from the canonical advance definition for
 that career, so you only need to adjust the page number when editing manually.
+
+## Sample character workflow
+
+Two helper scripts in the `scripts/` directory showcase a complete character sheet with
+stats, XP bookkeeping, skills, talents, equipment, armour, and a detailed list of
+actions:
+
+```bash
+# Create sample_character.json (overwrites the file if it already exists)
+python scripts/generate_sample_character.py
+
+# Tweak the sheet in-place: update XP, add skills, or change the actions list
+python scripts/modify_character.py sample_character.json \
+  --set-xp-total 1250 \
+  --set-skill "Dodge=+10" \
+  --add-action "Hail Mary|Full Action|Throw a frag grenade with +20 to hit|Explosive"
+```
+
+Running the generator prints the character's actions so they can be quickly copied into
+session prep notes, while the modifier recalculates available XP after each change.

--- a/sample_character.json
+++ b/sample_character.json
@@ -1,0 +1,121 @@
+{
+  "name": "Sergeant Elara Voss",
+  "career": "Soldier",
+  "stats": {
+    "Weapon Skill": 45,
+    "Ballistic Skill": 52,
+    "Strength": 38,
+    "Toughness": 41,
+    "Agility": 42,
+    "Intelligence": 37,
+    "Perception": 43,
+    "Willpower": 46,
+    "Fellowship": 35
+  },
+  "xp": {
+    "total": 1250,
+    "spent": 900,
+    "available": 350
+  },
+  "skills": [
+    {
+      "name": "Awareness",
+      "status": "Trained"
+    },
+    {
+      "name": "Command",
+      "status": "+10"
+    },
+    {
+      "name": "Intimidate",
+      "status": "+5"
+    },
+    {
+      "name": "Medicae",
+      "status": "Trained"
+    },
+    {
+      "name": "Parry",
+      "status": "+10"
+    },
+    {
+      "name": "Scrutiny",
+      "status": "Untrained"
+    },
+    {
+      "name": "Dodge",
+      "status": "+10"
+    }
+  ],
+  "talents": [
+    "Air of Authority",
+    "Bolter Drill",
+    "Combat Sense",
+    "Iron Jaw",
+    "Nerves of Steel",
+    "Rapid Reload"
+  ],
+  "equipment": [
+    "Mk IX Pattern Carapace Armour",
+    "Accatran Pattern Assault Bolter",
+    "Melta Bomb",
+    "Micro-bead",
+    "Rebreather",
+    "Regimental Medkit"
+  ],
+  "armour": {
+    "head": {
+      "item": "Carapace Helmet",
+      "ap": 6
+    },
+    "body": {
+      "item": "Carapace Breastplate",
+      "ap": 6
+    },
+    "arms": {
+      "item": "Carapace Pauldrons",
+      "ap": 5
+    },
+    "legs": {
+      "item": "Carapace Greaves",
+      "ap": 5
+    }
+  },
+  "actions": [
+    {
+      "name": "Suppressing Fire",
+      "type": "Full Action",
+      "description": "Lay down a hail of shots with the Accatran assault bolter. Targets in the area must test Pinning.",
+      "keywords": [
+        "Ranged",
+        "Bolter"
+      ]
+    },
+    {
+      "name": "Coordinated Strike",
+      "type": "Half Action",
+      "description": "Issue battlefield orders granting +10 to allies' next Weapon Skill test against a designated enemy.",
+      "keywords": [
+        "Command",
+        "Support"
+      ]
+    },
+    {
+      "name": "Vicious Riposte",
+      "type": "Reaction",
+      "description": "After a successful Parry, immediately make a counterattack with the combat knife at +10 Weapon Skill.",
+      "keywords": [
+        "Melee",
+        "Counter"
+      ]
+    },
+    {
+      "name": "Hail Mary",
+      "type": "Full Action",
+      "description": "Throw a frag grenade with +20 to hit",
+      "keywords": [
+        "Explosive"
+      ]
+    }
+  ]
+}

--- a/scripts/generate_sample_character.py
+++ b/scripts/generate_sample_character.py
@@ -1,0 +1,138 @@
+"""Generate a sample Dark Heresy character profile in JSON format."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def _build_sample_character() -> Dict[str, Any]:
+    """Return a ready-to-use sample character payload.
+
+    The payload is intentionally verbose so that downstream tooling has
+    everything it needs to present the character sheet without extra
+    bookkeeping.  When updating XP totals we keep both the spent value and
+    an "available" field to make it immediately obvious how much room the
+    character has left for growth.
+    """
+
+    stats: Dict[str, int] = {
+        "Weapon Skill": 45,
+        "Ballistic Skill": 52,
+        "Strength": 38,
+        "Toughness": 41,
+        "Agility": 42,
+        "Intelligence": 37,
+        "Perception": 43,
+        "Willpower": 46,
+        "Fellowship": 35,
+    }
+
+    xp_total = 1150
+    xp_spent = 850
+
+    skills: List[Dict[str, Any]] = [
+        {"name": "Awareness", "status": "Trained"},
+        {"name": "Command", "status": "+10"},
+        {"name": "Intimidate", "status": "+5"},
+        {"name": "Medicae", "status": "Trained"},
+        {"name": "Parry", "status": "+10"},
+        {"name": "Scrutiny", "status": "Untrained"},
+    ]
+
+    talents = [
+        "Air of Authority",
+        "Bolter Drill",
+        "Combat Sense",
+        "Iron Jaw",
+        "Nerves of Steel",
+        "Rapid Reload",
+    ]
+
+    equipment = [
+        "Mk IX Pattern Carapace Armour",
+        "Accatran Pattern Assault Bolter",
+        "Melta Bomb",
+        "Micro-bead",
+        "Rebreather",
+        "Regimental Medkit",
+    ]
+
+    armour = {
+        "head": {"item": "Carapace Helmet", "ap": 6},
+        "body": {"item": "Carapace Breastplate", "ap": 6},
+        "arms": {"item": "Carapace Pauldrons", "ap": 5},
+        "legs": {"item": "Carapace Greaves", "ap": 5},
+    }
+
+    actions: List[Dict[str, Any]] = [
+        {
+            "name": "Suppressing Fire",
+            "type": "Full Action",
+            "description": "Lay down a hail of shots with the Accatran assault bolter. Targets in the area must test Pinning.",
+            "keywords": ["Ranged", "Bolter"],
+        },
+        {
+            "name": "Coordinated Strike",
+            "type": "Half Action",
+            "description": "Issue battlefield orders granting +10 to allies' next Weapon Skill test against a designated enemy.",
+            "keywords": ["Command", "Support"],
+        },
+        {
+            "name": "Brace for Impact",
+            "type": "Reaction",
+            "description": "Spend a reaction to gain +10 to Agility tests to avoid blasts and reduce incoming damage by 2 until the start of the next turn.",
+            "keywords": ["Defensive"],
+        },
+        {
+            "name": "Vicious Riposte",
+            "type": "Reaction",
+            "description": "After a successful Parry, immediately make a counterattack with the combat knife at +10 Weapon Skill.",
+            "keywords": ["Melee", "Counter"],
+        },
+    ]
+
+    return {
+        "name": "Sergeant Elara Voss",
+        "career": "Soldier",
+        "stats": stats,
+        "xp": {
+            "total": xp_total,
+            "spent": xp_spent,
+            "available": xp_total - xp_spent,
+        },
+        "skills": skills,
+        "talents": talents,
+        "equipment": equipment,
+        "armour": armour,
+        "actions": actions,
+    }
+
+
+def _save_character(payload: Dict[str, Any], destination: Path) -> None:
+    destination.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a sample character sheet.")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("sample_character.json"),
+        help="Where to write the sample JSON file (default: sample_character.json).",
+    )
+    args = parser.parse_args()
+
+    character = _build_sample_character()
+    _save_character(character, args.output)
+
+    print(f"Sample character written to {args.output}.")
+    print("Actions available:")
+    for action in character["actions"]:
+        print(f" - {action['name']} ({action['type']}): {action['description']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/modify_character.py
+++ b/scripts/modify_character.py
@@ -1,0 +1,156 @@
+"""Utility for tweaking generated character JSON files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+CharacterPayload = Dict[str, Any]
+
+
+def _load(path: Path) -> CharacterPayload:
+    return json.loads(path.read_text())
+
+
+def _save(data: CharacterPayload, path: Path) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def _ensure_xp_available(data: CharacterPayload) -> None:
+    xp_block = data.setdefault("xp", {})
+    total = int(xp_block.get("total", 0))
+    spent = int(xp_block.get("spent", 0))
+    xp_block["available"] = total - spent
+
+
+def _set_skill(data: CharacterPayload, spec: str) -> None:
+    if "=" not in spec:
+        raise ValueError("Skill specification must look like 'Skill Name=Status'.")
+    name, status = [part.strip() for part in spec.split("=", 1)]
+    if not name:
+        raise ValueError("Skill name cannot be empty.")
+    if not status:
+        raise ValueError("Skill status cannot be empty.")
+
+    skills: List[Dict[str, Any]] = data.setdefault("skills", [])
+    for skill in skills:
+        if skill.get("name", "").lower() == name.lower():
+            skill["status"] = status
+            break
+    else:
+        skills.append({"name": name, "status": status})
+
+
+def _remove_action(data: CharacterPayload, name: str) -> bool:
+    actions: List[Dict[str, Any]] = data.get("actions", [])
+    original_len = len(actions)
+    data["actions"] = [action for action in actions if action.get("name", "").lower() != name.lower()]
+    return len(data["actions"]) != original_len
+
+
+def _add_action(data: CharacterPayload, spec: str) -> None:
+    parts = [part.strip() for part in spec.split("|") if part.strip()]
+    if len(parts) < 3:
+        raise ValueError("Action spec must be 'Name|Type|Description' with optional '|keyword1,keyword2'.")
+    name, action_type, description = parts[:3]
+    keywords: List[str] = []
+    if len(parts) > 3:
+        keywords = [kw.strip() for kw in parts[3].split(",") if kw.strip()]
+
+    actions: List[Dict[str, Any]] = data.setdefault("actions", [])
+    actions.append(
+        {
+            "name": name,
+            "type": action_type,
+            "description": description,
+            "keywords": keywords,
+        }
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Modify a generated character JSON file.")
+    parser.add_argument("file", type=Path, help="Character JSON file to modify")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional output path. If omitted the input file is modified in place.",
+    )
+    parser.add_argument("--set-xp-total", type=int, help="Set the character's total XP")
+    parser.add_argument("--set-xp-spent", type=int, help="Set the character's spent XP")
+    parser.add_argument(
+        "--set-skill",
+        action="append",
+        default=[],
+        metavar="NAME=STATUS",
+        help="Update a skill entry, e.g. 'Dodge=+10'. New skills are created if needed.",
+    )
+    parser.add_argument(
+        "--add-action",
+        action="append",
+        default=[],
+        metavar="NAME|TYPE|DESCRIPTION[|keywords]",
+        help="Append an action. Example: 'Hunker Down|Half Action|Gain +20 to cover saves|Defensive,Utility'",
+    )
+    parser.add_argument(
+        "--remove-action",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="Remove an action by name (case-insensitive).",
+    )
+    return parser
+
+
+def apply_changes(data: CharacterPayload, args: argparse.Namespace) -> List[str]:
+    messages: List[str] = []
+
+    if args.set_xp_total is not None:
+        data.setdefault("xp", {})["total"] = args.set_xp_total
+        messages.append(f"XP total set to {args.set_xp_total}.")
+    if args.set_xp_spent is not None:
+        data.setdefault("xp", {})["spent"] = args.set_xp_spent
+        messages.append(f"XP spent set to {args.set_xp_spent}.")
+
+    for skill_spec in args.set_skill:
+        _set_skill(data, skill_spec)
+        messages.append(f"Skill updated: {skill_spec}.")
+
+    for action_spec in args.add_action:
+        _add_action(data, action_spec)
+        messages.append(f"Action added: {action_spec.split('|', 1)[0].strip()}.")
+
+    for name in args.remove_action:
+        removed = _remove_action(data, name)
+        if removed:
+            messages.append(f"Action removed: {name}.")
+        else:
+            messages.append(f"No action named '{name}' found.")
+
+    _ensure_xp_available(data)
+    return messages
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    payload = _load(args.file)
+    messages = apply_changes(payload, args)
+
+    output_path = args.output or args.file
+    _save(payload, output_path)
+
+    print(f"Character saved to {output_path}.")
+    for message in messages:
+        print(f" - {message}")
+
+    print("Updated actions list:")
+    for action in payload.get("actions", []):
+        print(f" * {action['name']} ({action.get('type', 'Unknown')}): {action.get('description', 'No description')}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a standalone generator that writes a fully populated sample character sheet and highlights the action list
- provide a modifier utility for tweaking XP, skills, and actions while keeping XP totals in sync
- check in the generated example sheet and document the workflow in the README

## Testing
- python scripts/generate_sample_character.py --output sample_character.json
- python scripts/modify_character.py sample_character.json --set-xp-total 1250 --set-xp-spent 900 --set-skill "Dodge=+10" --add-action "Hail Mary|Full Action|Throw a frag grenade with +20 to hit|Explosive" --remove-action "Brace for Impact"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914577cef44832785e7c44f80a82d73)